### PR TITLE
libc 的更新以及 mkfs 的错误修复

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ UPROGS=\
 	$U/init \
 	$U/sh \
 	$U/cat  \
+	$U/ls  \
 
 CPUS = 1
 

--- a/ulibc/CMakeLists.txt
+++ b/ulibc/CMakeLists.txt
@@ -9,7 +9,9 @@ set (
     # process
     ${PROJECT_SOURCE_DIR}/ulibc/src/process/wait.c
     # stat
+    ${PROJECT_SOURCE_DIR}/ulibc/src/stat/fstat.c
     ${PROJECT_SOURCE_DIR}/ulibc/src/stat/mknod.c
+    ${PROJECT_SOURCE_DIR}/ulibc/src/stat/stat.c
     # stdio
     # ${PROJECT_SOURCE_DIR}/ulibc/src/stdio/__lockfile.c
     ${PROJECT_SOURCE_DIR}/ulibc/src/stdio/__stdio_read.c
@@ -30,7 +32,11 @@ set (
     # string
     ${PROJECT_SOURCE_DIR}/ulibc/src/string/memchr.c
     ${PROJECT_SOURCE_DIR}/ulibc/src/string/memcpy.c
+    ${PROJECT_SOURCE_DIR}/ulibc/src/string/memmove.c
     ${PROJECT_SOURCE_DIR}/ulibc/src/string/memset.c
+    ${PROJECT_SOURCE_DIR}/ulibc/src/string/strcpy.c
+    ${PROJECT_SOURCE_DIR}/ulibc/src/string/strcpy.c
+    ${PROJECT_SOURCE_DIR}/ulibc/src/string/strlen.c
     ${PROJECT_SOURCE_DIR}/ulibc/src/string/strnlen.c
     # unistd
     ${PROJECT_SOURCE_DIR}/ulibc/src/unistd/close.c

--- a/ulibc/crt/crt1.c
+++ b/ulibc/crt/crt1.c
@@ -1,8 +1,9 @@
 #include "syscall.h"
-void
-_start()
+
+int main();
+
+void _start()
 {
-  extern int main();
   main();
   syscall(SYS_exit, 0);
 }

--- a/ulibc/include/dirent.h
+++ b/ulibc/include/dirent.h
@@ -1,0 +1,16 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdint.h>
+
+#define DIRSIZ 14
+
+struct dirent {
+  uint16_t inum;
+  char name[DIRSIZ];
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/ulibc/include/sys/stat.h
+++ b/ulibc/include/sys/stat.h
@@ -1,3 +1,26 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
+#define T_DIR     1   // Directory
+#define T_FILE    2   // File
+#define T_DEVICE  3   // Device
+
+struct stat {
+  uint32_t dev;
+  uint32_t ino;
+  int16_t type;
+  int16_t nlink;
+  uint64_t size;
+};
+
 int mknod(const char *, uint32_t, uint64_t);
+int stat(const char *__restrict, struct stat *__restrict);
+int fstat(int, struct stat *);
+
+#ifdef __cplusplus
+}
+#endif

--- a/ulibc/src/stat/fstat.c
+++ b/ulibc/src/stat/fstat.c
@@ -1,0 +1,5 @@
+#include <sys/stat.h>
+
+#include "syscall.h"
+
+int fstat(int fd, struct stat* stat) { return syscall(SYS_fstat, fd, stat); }

--- a/ulibc/src/stat/stat.c
+++ b/ulibc/src/stat/stat.c
@@ -1,0 +1,13 @@
+#include <fnctl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int stat(const char *__restrict path, struct stat *__restrict buf) {
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    return -1;
+  }
+  int rs = fstat(fd, buf);
+  close(fd);
+  return rs;
+}

--- a/ulibc/src/stdio/fwrite.c
+++ b/ulibc/src/stdio/fwrite.c
@@ -1,18 +1,38 @@
 #include <stddef.h>
 #include <string.h>
-#include "stdio_impl.h"
 
-size_t __fwritex(const unsigned char *restrict s, size_t l, FILE *restrict f)
-{
- return f->write(f, s, l);
+#include "stdio_impl.h"
+#include "syscall.h"
+
+size_t __fwritex(const unsigned char *restrict s, size_t l, FILE *restrict f) {
+  size_t i=0;
+
+	if (!f->wend && __towrite(f)) return 0;
+
+	if ((long)l > f->wend - f->wpos) return f->write(f, s, l);
+
+	if (f->lbf >= 0) {
+		/* Match /^(.*\n|)/ */
+		for (i=l; i && s[i-1] != '\n'; i--);
+		if (i) {
+			size_t n = f->write(f, s, i);
+			if (n < i) return n;
+			s += i;
+			l -= i;
+		}
+	}
+
+	memcpy(f->wpos, s, l);
+	f->wpos += l;
+	return l+i;
 }
 
-size_t fwrite(const void *restrict src, size_t size, size_t nmemb, FILE *restrict f)
-{
-	size_t k, l = size*nmemb;
-	if (!size) nmemb = 0;
-	// FLOCK(f);
-	k = __fwritex(src, l, f);
-	// FUNLOCK(f);
-	return k==l ? nmemb : k/size;
+size_t fwrite(const void *restrict src, size_t size, size_t nmemb,
+              FILE *restrict f) {
+  size_t k, l = size * nmemb;
+  if (!size) nmemb = 0;
+  // FLOCK(f);
+  k = __fwritex(src, l, f);
+  // FUNLOCK(f);
+  return k == l ? nmemb : k / size;
 }

--- a/ulibc/src/stdio/vfprintf.c
+++ b/ulibc/src/stdio/vfprintf.c
@@ -4,11 +4,17 @@
 #include <string.h>
 
 #include "stdio_impl.h"
+#include "syscall.h"
 
 static const char xdigits[16] = {"0123456789ABCDEF"};
 
 static void out(FILE *f, const char *s, size_t l) {
-  if (!ferror(f)) __fwritex((void *)s, l, f);
+  // if (f == stdout) {
+  //   syscall(SYS_write, 1, s, l);
+  // }
+  if (!ferror(f)) {
+    __fwritex((void *)s, l, f);
+  }
 }
 
 static void printint(FILE *restrict f, int xx, int base, int sgn) {

--- a/ulibc/src/string/memmove.c
+++ b/ulibc/src/string/memmove.c
@@ -1,0 +1,24 @@
+#include <stddef.h>
+
+void *memmove(void *dest, const void *src, size_t n) {
+  if (!dest || !src) {
+    return NULL;
+  }
+
+  unsigned char *d = (unsigned char *)dest;
+  const unsigned char *s = (const unsigned char *)src;
+
+  if (d < s || d >= s + n) {
+    while (n--) {
+      *d++ = *s++;
+    }
+  } else if (d > s) {
+    d += n;
+    s += n;
+    while (n--) {
+      *--d = *--s;
+    }
+  }
+
+  return dest;
+}

--- a/ulibc/src/string/strcpy.c
+++ b/ulibc/src/string/strcpy.c
@@ -1,0 +1,13 @@
+#include "type.h"
+
+char* strcpy(char* __restrict dest, const char* __restrict src) {
+  if (!dest || !src) {
+    return NULL;
+  }
+
+  char* original = dest;
+  while ((*dest++ = *src++)) {
+  }
+
+  return original;
+}

--- a/ulibc/src/string/strlen.c
+++ b/ulibc/src/string/strlen.c
@@ -1,0 +1,9 @@
+#include <stddef.h>
+
+size_t strlen(const char *str) {
+    const char *s = str;
+    while (*s) {
+        ++s;
+    }
+    return s - str;
+}

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -6,26 +6,21 @@ set(
     ${PROJECT_SOURCE_DIR}/kernel/include
 )
 
+set(UTILS_EXECUTABLES cat init ls sh)
+
 set (CMAKE_CXX_FLAGS "-target riscv64-unknown-elf -march=rv64g -mabi=lp64 -nostdlib -nostdlib++ -mcmodel=medany")
 set (CMAKE_C_FLAGS "-target riscv64-unknown-elf -march=rv64g -mabi=lp64 -nostdlib -mcmodel=medany -fno-stack-protector -fno-pie")
 set (CMAKE_ASM_FLAGS "-target riscv64-unknown-elf -march=rv64g -mabi=lp64 -nostdlib -nostdlib++")
 
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-common -nostdlib -Wno-main -fno-builtin-strncpy -fno-builtin-strncmp -fno-builtin-strlen -fno-builtin-memset -fno-builtin-memmove -fno-builtin-memcmp -fno-builtin-log -fno-builtin-bzero -fno-builtin-strchr -fno-builtin-exit -fno-builtin-malloc -fno-builtin-putc -fno-builtin-free -fno-builtin-memcpy -Wno-main -fno-builtin-printf -fno-builtin-fprintf -fno-builtin-vprintf")
 
-add_executable(init ${PROJECT_SOURCE_DIR}/utils/init.c)
-add_executable(cat ${PROJECT_SOURCE_DIR}/utils/cat.c)
-add_executable(sh ${PROJECT_SOURCE_DIR}/utils/sh.c)
-add_executable(initcode ${PROJECT_SOURCE_DIR}/utils/initcode.S)
-
 include_directories(${UTILS_LIBCPP_INCLUDE})
 
-target_link_libraries(init PRIVATE crt1 ulibc)
-target_link_options(init PRIVATE "-Wl,-T${CMAKE_SOURCE_DIR}/utils/user.ld,-z,max-page-size=4096")
+foreach(exe ${UTILS_EXECUTABLES})
+  add_executable(${exe} ${PROJECT_SOURCE_DIR}/utils/${exe}.c)
+  target_link_libraries(${exe} PRIVATE crt1 ulibc)
+  target_link_options(${exe} PRIVATE "-Wl,-T${CMAKE_SOURCE_DIR}/utils/user.ld,-z,max-page-size=4096")
+endforeach()
 
-target_link_libraries(cat PRIVATE crt1 ulibc)
-target_link_options(cat PRIVATE "-Wl,-T${CMAKE_SOURCE_DIR}/utils/user.ld,-z,max-page-size=4096")
-
-target_link_libraries(sh PRIVATE crt1 ulibc)
-target_link_options(sh PRIVATE "-Wl,-T${CMAKE_SOURCE_DIR}/utils/user.ld,-z,max-page-size=4096")
-
+add_executable(initcode ${PROJECT_SOURCE_DIR}/utils/initcode.S)
 target_link_options(initcode PRIVATE "-Wl,-N,-e,start,-Ttext,0")

--- a/utils/init.c
+++ b/utils/init.c
@@ -12,7 +12,7 @@ int main() {
   }
   dup(0);  // stdout
   dup(0);  // stderr
-  printf("init process start\n");
+  printf("init process start\n\n");
   if (fork() == 0) {
     execve("sh", argv, NULL);
   }

--- a/utils/ls.c
+++ b/utils/ls.c
@@ -1,0 +1,83 @@
+#include <dirent.h>
+#include <fnctl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+void ls(char *path);
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    ls(".");
+    return 0;
+  }
+  for (int i = 1; i < argc; i++) {
+    ls(argv[i]);
+  }
+  return 0;
+}
+
+char *fmtname(char *path) {
+  static char buf[DIRSIZ + 1];
+  char *p = NULL;
+
+  for (p = path + strlen(path); p >= path && *p != '/'; p--);
+  p++;
+
+  if (strlen(p) >= DIRSIZ) {
+    return p;
+  }
+  memmove(buf, p, strlen(p));
+  memset(buf + strlen(p), ' ', DIRSIZ - strlen(p));
+  return buf;
+}
+
+void ls(char *path) {
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    printf("ls: cannot open %s\n", path);
+    exit(1);
+  }
+
+  struct stat st;
+  if (fstat(fd, &st) < 0) {
+    printf("ls: cannot stat %s\n", path);
+    close(fd);
+    exit(1);
+  }
+
+  char buf[512];
+  char *p = NULL;
+  struct dirent de;
+
+  switch (st.type) {
+    case T_DEVICE:
+    case T_FILE:
+      printf("%s %d %d %d\n", fmtname(path), st.type, st.ino, (int)st.size);
+      break;
+
+    case T_DIR:
+      if (strlen(path) + 1 + DIRSIZ + 1 > sizeof buf) {
+        printf("ls: path too long\n");
+        break;
+      }
+      strcpy(buf, path);
+      p = buf + strlen(buf);
+      *p++ = '/';
+      while (read(fd, &de, sizeof(de)) == sizeof(de)) {
+        if (de.inum == 0) continue;
+        memmove(p, de.name, DIRSIZ);
+        p[DIRSIZ] = 0;
+        if (stat(buf, &st) < 0) {
+          printf("ls: cannot stat %s\n", buf);
+          continue;
+        }
+        const char *name = fmtname(buf);
+        printf("%s %d %d %d\n", name, st.type, st.ino, (int)st.size);
+      }
+      break;
+  }
+  close(fd);
+}

--- a/utils/sh.c
+++ b/utils/sh.c
@@ -18,6 +18,7 @@ int main(void) {
   int fd = 0;
   static char buf[100];
   char *argv[] = {"cat", "README.md", 0};
+  // char *argv[] = {"ls", 0};
 
   while ((fd = open("console", O_RDWR)) >= 0) {
     if (fd >= 3) {


### PR DESCRIPTION
- mkfs
  - 修复了无法完整地读取文件的错误
- libc
  - 添加了如 `fstat`, `strlen`, `memmove` 的实现
- utils
  - 添加了 ls 的实现，并更改了 utils 中 CMakeLists.txt 用户程序的声明方式